### PR TITLE
Conditional test

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,6 +66,11 @@ jobs:
             any::XML
             any::textshaping
 
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          build_args: 'c("--no-manual", "--no-build-vignettes")'
+          args: 'c("--no-manual", "--as-cran", "--ignore-vignettes")'
+
       - uses: ./.github/actions/cmdstanr_cached
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,11 +22,14 @@ Imports:
 Suggests: 
     testthat,
     rstan,
-    cmdstanr,
     knitr,
     rmarkdown,
     parallel,
     bayesplot
+Enhancements:
+    cmdstanr
+Additional_repositories:
+    stan-dev
 VignetteBuilder: knitr
 Config/testthat/parallel: true
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,8 +28,6 @@ Suggests:
     bayesplot
 Enhancements:
     cmdstanr
-Additional_repositories:
-    stan-dev
 VignetteBuilder: knitr
 Config/testthat/parallel: true
 Config/testthat/edition: 3

--- a/tests/testthat/test-moment-match-cmdstan-analytical.R
+++ b/tests/testthat/test-moment-match-cmdstan-analytical.R
@@ -1,4 +1,8 @@
-library(cmdstanr)
+cmdstanr_available = require(cmdstanr)
+
+# Run these tests only if cmdstanr is installed
+if(cmdstanr_available){
+
 
 stancode <- "data {
   int<lower=0> N;
@@ -166,3 +170,6 @@ test_that("moment_match.CmdStanFit matches analytical results", {
   )
 
 })
+
+
+} # close conditional on cmdstanr

--- a/tests/testthat/test-moment-match-cmdstan-analytical.R
+++ b/tests/testthat/test-moment-match-cmdstan-analytical.R
@@ -1,7 +1,7 @@
-cmdstanr_available = require(cmdstanr)
+cmdstanr_available <- require(cmdstanr)
 
 # Run these tests only if cmdstanr is installed
-if(cmdstanr_available){
+if(cmdstanr_available) {
 
 
 stancode <- "data {


### PR DESCRIPTION
Only run the tests in test-moment-match-cmdstan-analytical.R if CmdStanR is installed.

 - Add an if guard to avoid running the tests.
 - Move CmdStanR to Enhancements in DESCRIPTION. Suggestions need to be installed when running tests.
 - Add the repository for CmdStanR to Additional_repositories in DESCRIPTION.
 - Run the tests before and after installing CmdStanR in the workflow.